### PR TITLE
13 - fix using modin typo, change pip installs to link ref of modin repo

### DIFF
--- a/data-analysis/13-data-processing.ipynb
+++ b/data-analysis/13-data-processing.ipynb
@@ -451,7 +451,9 @@
    "metadata": {},
    "source": [
     "## Introduction to Modin\n",
+    "\n",
     "Modin was designed for terrabyte sized data sets by splitting the dataframe into smaller more manageble units allowing it to be loaded into separate processors and memory thus, parallelizing your Python code. \n",
+    "\n",
     "It covers 90% of the Pandas API with a focus on the most commonly used Pandas methods. Modin is a superset of Pandas which means the remaining falls back to native Pandas. "
    ]
   },
@@ -468,13 +470,11 @@
    "id": "direct-conditioning",
    "metadata": {},
    "source": [
-    "# Using Modin\n",
-    "Modin includes a scheduler that abstracts the hardware from the interpreter so that you don't need to know manage it within your code.\n",
-    "To install it all you need: <br />\n",
-    "    `pip install modin[ray]`<br />\n",
-    "    `pip install modin[dask]`<br />\n",
-    "    `pip install modin[all]`\n",
-    " "
+    "## Using Modin\n",
+    "\n",
+    "Modin includes a scheduler that abstracts the hardware from the interpreter so that you don't need to manage it within your code.\n",
+    "\n",
+    "You can learn more about how to install and use it at https://github.com/modin-project/modin."
    ]
   },
   {
@@ -1835,8 +1835,17 @@
    "source": [
     "- [https://blog.floydhub.com/multiprocessing-vs-threading-in-python-what-every-data-scientist-needs-to-know/](https://blog.floydhub.com/multiprocessing-vs-threading-in-python-what-every-data-scientist-needs-to-know/)\n",
     "- [https://timber.io/blog/multiprocessing-vs-multithreading-in-python-what-you-need-to-know/](https://timber.io/blog/multiprocessing-vs-multithreading-in-python-what-you-need-to-know/)\n",
-    "- [https://www.educative.io/edpresso/what-is-multithreading-in-python](https://www.educative.io/edpresso/what-is-multithreading-in-python)"
+    "- [https://www.educative.io/edpresso/what-is-multithreading-in-python](https://www.educative.io/edpresso/what-is-multithreading-in-python)\n",
+    "- [Modin official repository](https://github.com/modin-project/modin)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7346ef66-d087-4234-9c23-1a35c81b7336",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -1855,7 +1864,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
![using](https://user-images.githubusercontent.com/2837532/121751521-4be75600-cadc-11eb-90ea-71021845ee59.png)

- reduced one level of the header for the subtitle "Using Modin"
- fix typo ~~know manage~~ to `manage`
- change `pip install`s to link ref of modin repo